### PR TITLE
Handle WURFL Cloud outages better

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var defaultConfig = {
 	username: '',
 	password: '',
 	capabilities: [],
+	timeout: 2000, // milliseconds to wait for the server to respond
 	ttl: 30 * 24 * 3600 // 30 days
 };
 
@@ -38,7 +39,8 @@ var internal = {
 				'User-Agent': ua,
 				'X-Cloud-Client': 'nodejs/wurfl-cloud-client ' + internal.version
 			}, headers || {}),
-			gzip: true
+			gzip: true,
+			timeout: timeout
 		};
 
 		request(requestOptions, function(err, response, body){

--- a/lib/index.js
+++ b/lib/index.js
@@ -256,7 +256,7 @@ var client = module.exports = {
 				req.headers['user-agent'],
 				internal.prepareHeaders(req),
 				function(err, result){
-					if (!err && result.capabilities) {
+					if (!err && result && result.capabilities) {
 						req.capabilities = result.capabilities;
 					}
 					next();


### PR DESCRIPTION
Hey @avaly!

How are you doing?

We had an incident yesterday where WURFL Cloud was down. That led to errors like this one:

<img width="877" alt="screen shot 2018-06-19 at 2 48 08 pm" src="https://user-images.githubusercontent.com/856108/41637111-74fd8a7a-7452-11e8-9a56-a7e1e0f95dd9.png">

I have patched the library to handle these cases a little better. Please take a look and suggest any changes you'd like :bowing_man: 

See you!
